### PR TITLE
chore: use retract to try to invalidate the v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/ccoveille/go-safecast
 
 go 1.21
+
+retract (
+    v1.0.0 // Published accidentally.
+)


### PR DESCRIPTION
This version was not ready for production, but was published without prerelease flag

Fixes #24

More information about retract in the go.mod documentation
https://go.dev/ref/mod#go-mod-file-retract
