### PR TITLE
feat: add conversion to float32 and float64

### DIFF
--- a/asserters.go
+++ b/asserters.go
@@ -33,6 +33,11 @@ func getUpperBoundary(value any) any {
 		upper = uint64(math.MaxUint64)
 	case uint:
 		upper = uint(math.MaxUint)
+
+	// Note: there is no float64 boundary
+	// because float64 cannot overflow
+	case float32:
+		upper = float32(math.MaxFloat32)
 	}
 
 	return upper
@@ -61,6 +66,12 @@ func getLowerBoundary(value any) any {
 		lower = uint32(0)
 	case uint64:
 		lower = uint64(0)
+
+	// Note: there is no float64 boundary
+	// because float64 cannot overflow
+	case float32:
+		lower = float32(-math.MaxFloat32)
+
 	}
 
 	return lower

--- a/asserters_test.go
+++ b/asserters_test.go
@@ -378,3 +378,51 @@ func assertUintError[in safecast.Number](t *testing.T, tests []caseUint[in]) {
 		})
 	}
 }
+
+type caseFloat32[in safecast.Number] struct {
+	name  string
+	input in
+	want  float32
+}
+
+func assertFloat32OK[in safecast.Number](t *testing.T, tests []caseFloat32[in]) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safecast.ToFloat32(tt.input)
+			assertNoError(t, err)
+			assertEqual(t, tt.want, got)
+		})
+	}
+}
+
+func assertFloat32Error[in safecast.Number](t *testing.T, tests []caseFloat32[in]) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safecast.ToFloat32(tt.input)
+			requireErrorIs(t, err, safecast.ErrConversionIssue)
+			assertEqual(t, tt.want, got)
+		})
+	}
+}
+
+type caseFloat64[in safecast.Number] struct {
+	name  string
+	input in
+	want  float64
+}
+
+func assertFloat64OK[in safecast.Number](t *testing.T, tests []caseFloat64[in]) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safecast.ToFloat64(tt.input)
+			assertNoError(t, err)
+			assertEqual(t, tt.want, got)
+		})
+	}
+}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1280,3 +1280,200 @@ func TestToUint(t *testing.T) {
 		})
 	})
 }
+
+func TestToFloat32(t *testing.T) {
+	t.Run("from int", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[int]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int8", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[int8]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int16", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[int16]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int32", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[int32]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int64", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[int64]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[uint]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint8", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[uint8]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint16", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[uint16]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint32", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[uint32]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint64", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[uint64]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from float32", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[float32]{
+			{name: "zero", input: 0.0, want: 0.0},
+			{name: "rounded value", input: 1.1, want: 1.1},
+			{name: "negative within range", input: -100.9, want: -100.9},
+			{name: "positive within range", input: 100.9, want: 100.9},
+		})
+	})
+
+	t.Run("from float64", func(t *testing.T) {
+		assertFloat32OK(t, []caseFloat32[float64]{
+			{name: "zero", input: 0.0, want: 0.0},
+			{name: "negative zero", input: math.Copysign(0, -1), want: -0},
+			{name: "almost zero", input: math.SmallestNonzeroFloat32, want: 1e-45},
+			{name: "almost negative zero", input: -math.SmallestNonzeroFloat32, want: -1e-45},
+			{name: "negative within range", input: -100.9, want: -100.9},
+			{name: "positive within range", input: 100.9, want: 100.9},
+			{name: "with imprecision due to conversion", input: 2.67428e+28, want: 2.67428e+28},
+		})
+
+		assertFloat32Error(t, []caseFloat32[float64]{
+			{name: "out of range max float32", input: math.MaxFloat32 * 1.02},  // because of float imprecision, we have to exceed the min int64 to trigger the error
+			{name: "out of range min float32", input: -math.MaxFloat32 * 1.02}, // because of float imprecision, we have to exceed the min int64 to trigger the error
+		})
+	})
+}
+
+func TestToFloat64(t *testing.T) {
+	t.Run("from int", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[int]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int8", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[int8]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int16", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[int16]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int32", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[int32]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from int64", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[int64]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "negative within range", input: -100, want: -100.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[uint]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint8", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[uint8]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint16", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[uint16]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint32", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[uint32]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from uint64", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[uint64]{
+			{name: "zero", input: 0, want: 0.0},
+			{name: "positive within range", input: 100, want: 100.0},
+		})
+	})
+
+	t.Run("from float32", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[float64]{
+			{name: "zero", input: 0.0, want: 0.0},
+			{name: "rounded value", input: 1.1, want: 1.1},
+			{name: "negative within range", input: -100.9, want: -100.9},
+			{name: "positive within range", input: 100.9, want: 100.9},
+		})
+	})
+
+	t.Run("from float64", func(t *testing.T) {
+		assertFloat64OK(t, []caseFloat64[float64]{
+			{name: "zero", input: 0.0, want: 0.0},
+			{name: "negative within range", input: -100.9, want: -100.9},
+			{name: "positive within range", input: 100.0, want: 100.0},
+		})
+	})
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -141,3 +141,31 @@ func ExampleToUint() {
 	// 42 <nil>
 	// 0 conversion issue: -1 (int8) is less than 0 (uint): minimum value for this type exceeded
 }
+
+func ExampleToFloat32() {
+	a := int8(42)
+	i, err := safecast.ToFloat32(a)
+	fmt.Println(i, err)
+
+	b := math.MaxFloat64
+	i, err = safecast.ToFloat32(b)
+	fmt.Println(i, err)
+
+	// Output:
+	// 42 <nil>
+	// 0 conversion issue: 1.7976931348623157e+308 (float64) is greater than 3.4028235e+38 (float32): maximum value for this type exceeded
+}
+
+func ExampleToFloat64() {
+	a := int8(42)
+	i, err := safecast.ToFloat64(a)
+	fmt.Println(i, err)
+
+	b := math.MaxFloat64
+	i, err = safecast.ToFloat64(b)
+	fmt.Println(i, err)
+
+	// Output:
+	// 42 <nil>
+	// 1.7976931348623157e+308 <nil>
+}


### PR DESCRIPTION
The only uses case that can overflow is when a float64 is stored in a float32

Fixes #19