### PR TITLE
feat: remove error and fmt.Stringer support

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -48,10 +48,6 @@ func Convert[NumOut Number](orig any) (converted NumOut, err error) {
 			o = 1
 		}
 		return NumOut(o), nil
-	case fmt.Stringer:
-		return convertFromString[NumOut](v.String())
-	case error:
-		return convertFromString[NumOut](v.Error())
 	case string:
 		return convertFromString[NumOut](v)
 	}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -16,22 +16,6 @@ import (
 	"github.com/ccoveille/go-safecast"
 )
 
-type anyStringer struct {
-	string
-}
-
-func (anyStringer) String() string {
-	return "42"
-}
-
-type anyError struct {
-	string
-}
-
-func (anyError) Error() string {
-	return "42"
-}
-
 func TestToInt8(t *testing.T) {
 	t.Run("from int", func(t *testing.T) {
 		assertInt8OK(t, []caseInt8[int]{
@@ -1633,9 +1617,6 @@ func TestConvert(t *testing.T) {
 
 				"boolean true":  {input: true, want: 1},
 				"boolean false": {input: false, want: 0},
-
-				"error":    {input: anyError{"42"}, want: 42},
-				"stringer": {input: anyStringer{"42"}, want: 42},
 			} {
 				t.Run(fmt.Sprintf("from %s", name), func(t *testing.T) {
 					got, err := converter(tt.input)


### PR DESCRIPTION
This is a BREAKING CHANGE! a minor one, but still a breaking change.

The error and fmt.Stringer types are no longer supported by the Convert and MustConvert functions.

I planned to support them, but I committed them too fast without thinking about possible issue it could bring.

I remove them as they are blocking for refactoring code.

Fixes #75 