### PR TITLE
ci: fix issue with golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,25 +157,8 @@ linters-settings:
       # warns when initialism, variable or package naming conventions are not followed.
       - name: var-naming
 
-  dupword:
-    # Keywords used to ignore detection.
-    # Default: []
-    ignore:
-    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
-
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Setting locale to US will correct the British spelling of 'colour' to 'color'.
     # Default ("") is to use a neutral variety of English.
     locale: US
-
-    # List of words to ignore
-    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
-    ignore-words:
-    #  - valor
-    #  - and
-
-    # Extra word corrections.
-    extra-words:
-    #  - typo: "whattever"
-    #    correction: "whatever"


### PR DESCRIPTION
The recent in golangci-lint-action added a verify step that checks the configuration file.

The golangci-lint was KO because of some small issues.
